### PR TITLE
fix: deploy agents data updates after refresh workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -7,9 +7,17 @@ on:
       - .gitignore
       - README.md
       - LICENSE
+  workflow_run:
+    workflows:
+      - "Refresh house price data"
+    types:
+      - completed
+    branches:
+      - master
 
 jobs:
   continuous-delivery:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `workflow_run` trigger to `Automatic build` workflow
- trigger deploy workflow when `Refresh house price data` completes on `master`
- only run deploy job for successful `workflow_run` events

## Problem
- house price data refresh workflow commits new `assets/data/house_price/hz.json` to `master`
- but current site deploy only listens to `push` events
- commits made by a workflow do not trigger another workflow with default `GITHUB_TOKEN`, so `gh-pages` can stay stale
- result: page can still show old `Updated` date (e.g. 2026-02-23) even though repository data has newer timestamps

## Validation
- verified repo data file currently has `"updated_at": "2026-04-05"`
- verified recent `Refresh house price data` runs are successful while `Automatic build` had no recent runs
- checked workflow syntax and condition:
  - `on.workflow_run.workflows: ["Refresh house price data"]`
  - `on.workflow_run.branches: [master]`
  - job guard: `if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'`

## Expected result after merge
- every successful data refresh triggers site rebuild/deploy automatically
- `https://johneyzheng.top/agents/` will pick up new `hz.json` data on next refresh cycle
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fafb4b2-5a92-4a4a-8f7c-51fa717e1b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fafb4b2-5a92-4a4a-8f7c-51fa717e1b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

